### PR TITLE
Split bug in classes definitions

### DIFF
--- a/src/mixins/BaseDiv.js
+++ b/src/mixins/BaseDiv.js
@@ -8,7 +8,10 @@ export const baseDiv = {
   computed: {
     classes() {
       if (!this.element.hasAttribute('classes')) {
-        return []
+        return [
+          this.$options.name.toLowerCase(),
+          []
+        ]
       }
       return [
         this.$options.name.toLowerCase(),

--- a/src/mixins/BaseDiv.js
+++ b/src/mixins/BaseDiv.js
@@ -7,6 +7,9 @@ export const baseDiv = {
 
   computed: {
     classes() {
+      if (!this.element.hasAttribute('classes')) {
+        return []
+      }
       return [
         this.$options.name.toLowerCase(),
         ...this.element.getAttribute('classes').split(' '),


### PR DESCRIPTION
Where the XML has container without classes, the javascript fails because it's not checking that there is a `classes` attribute before trying to split it.  