### PR TITLE
Swapping MathJax for KaTeX

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "core-js": "^3.6.5",
     "vue": "^2.6.11",
     "vue-highlightjs": "^1.3.3",
-    "vue-mathjax": "0.0.11",
+    "vue-katex": "^0.5.0",
     "vue-router": "^3.2.0",
     "vuex": "^3.5.1"
   },

--- a/public/index.html
+++ b/public/index.html
@@ -6,11 +6,6 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0" />
     <link rel="icon" href="<%= BASE_URL %>favicon.ico" />
     <title><%= htmlWebpackPlugin.options.title %></title>
-    <!-- <script
-      type="text/javascript"
-      async
-      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-MML-AM_CHTML"
-    ></script> -->
     <!-- KaTeX styles -->
     <link 
     rel="stylesheet" 

--- a/public/index.html
+++ b/public/index.html
@@ -6,11 +6,18 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0" />
     <link rel="icon" href="<%= BASE_URL %>favicon.ico" />
     <title><%= htmlWebpackPlugin.options.title %></title>
-    <script
+    <!-- <script
       type="text/javascript"
       async
       src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-MML-AM_CHTML"
-    ></script>
+    ></script> -->
+    <!-- KaTeX styles -->
+    <link 
+    rel="stylesheet" 
+    href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.9.0-alpha2/katex.min.css" 
+    integrity="sha384-exe4Ak6B0EoJI0ogGxjJ8rn+RN3ftPnEQrGwX59KTCl5ybGzvHGKjhPKk/KC3abb" 
+    crossorigin="anonymous"
+    >
   </head>
   <body>
     <noscript>

--- a/src/components/templates/Math.vue
+++ b/src/components/templates/Math.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="equation" v-katex="formula"></div>
+  <span class="equation" v-katex="formula"></span>
 </template>
 
 <script>

--- a/src/components/templates/Math.vue
+++ b/src/components/templates/Math.vue
@@ -1,15 +1,11 @@
 <template>
-  <vue-mathjax :formula="formula"> </vue-mathjax>
+  <div class="equation" v-katex="formula"></div>
 </template>
 
 <script>
-import { VueMathjax } from 'vue-mathjax'
 
 export default {
   name: 'Math',
-  components: {
-    'vue-mathjax': VueMathjax,
-  },
   props: {
     element: {
       type: Element,
@@ -18,8 +14,7 @@ export default {
 
   computed: {
     formula() {
-      let formula = this.element.textContent
-      return '$' + formula + '$'
+      return this.element.textContent
     },
   },
 }

--- a/src/components/templates/Math.vue
+++ b/src/components/templates/Math.vue
@@ -3,7 +3,6 @@
 </template>
 
 <script>
-
 export default {
   name: 'Math',
   props: {

--- a/src/components/templates/MathBlock.vue
+++ b/src/components/templates/MathBlock.vue
@@ -1,14 +1,25 @@
 <template>
-    <!-- TODO Not happy with how this works.  If they're rendered as separate equations then relative formatting will fail ... -->
-    <div>
-      <div v-for="formula in formulas" :key="'math_'+formula.index">
-        <div class="equation" v-katex:display="formula.formula"></div>
-      </div>
+  <!-- TODO Not happy with how this works.  If they're rendered as separate equations then relative 
+  formatting will fail ... but that's a problem for another day, when the alignment markup is actually recognised! -->
+  <div>
+    <div v-for="formula in formulas" :key="'math_' + formula.index">
+      <div class="equation" v-katex="formula.formula"></div>
     </div>
-  <!-- <div class="equation" v-katex="formulas"></div> -->
+  </div>
 </template>
 
 <script>
+// Unsupported delimiters/formatting.
+const skipList = [
+  '&amp;',
+  '\\begin{align}',
+  '\\begin{eqnarray}',
+  '\\begin{equation}',
+  '\\end{align}',
+  '\\end{eqnarray}',
+  '\\end{equation}',
+]
+
 export default {
   name: 'MathBlock',
   props: {
@@ -18,22 +29,18 @@ export default {
   },
 
   computed: {
-    // formulas() {
-    //   let eqn = this.element.innerHTML.replaceAll('&amp;','')
-    //   let head = '\\begin{align}\n'
-    //   let foot = '\n\\end{align}\n'
-    //   return head + eqn + foot
-    // }
     formulas() {
       let formulas = []
       let i = 0
       this.element.innerHTML.split(/\r?\n/).forEach((formula) => {
+        let stripped = formula.replaceAll('&amp;', '')
+        skipList.forEach(item=> {
+          stripped = stripped.replaceAll(item, '')
+        })
+
         if (formula) {
           formulas.push({
-            // TODO: Removing the & from the string, as this causes errors.  Not
-            // sure if it needs the "amsmath" plugin to be installed somewhere in order
-            // to work?
-            formula: formula.replaceAll('&amp;', ''),
+            formula: stripped,
             index: i,
           })
           i++

--- a/src/components/templates/MathBlock.vue
+++ b/src/components/templates/MathBlock.vue
@@ -1,22 +1,16 @@
 <template>
-  <div class="mathjax">
-    <vue-mathjax
-      v-for="(formula, index) in formulas"
-      :formula="formula"
-      :key="'math_formula_' + index"
-    >
-    </vue-mathjax>
-  </div>
+    <!-- TODO Not happy with how this works.  If they're rendered as separate equations then relative formatting will fail ... -->
+    <div>
+      <div v-for="formula in formulas" :key="'math_'+formula.index">
+        <div class="equation" v-katex:display="formula.formula"></div>
+      </div>
+    </div>
+  <!-- <div class="equation" v-katex="formulas"></div> -->
 </template>
 
 <script>
-import { VueMathjax } from 'vue-mathjax'
-
 export default {
   name: 'MathBlock',
-  components: {
-    'vue-mathjax': VueMathjax,
-  },
   props: {
     element: {
       type: Element,
@@ -24,11 +18,25 @@ export default {
   },
 
   computed: {
+    // formulas() {
+    //   let eqn = this.element.innerHTML.replaceAll('&amp;','')
+    //   let head = '\\begin{align}\n'
+    //   let foot = '\n\\end{align}\n'
+    //   return head + eqn + foot
+    // }
     formulas() {
       let formulas = []
-      this.element.innerHTML.split(/\r?\n/).forEach(formula => {
+      let i = 0
+      this.element.innerHTML.split(/\r?\n/).forEach((formula) => {
         if (formula) {
-          formulas.push('$$' + formula + '$$')
+          formulas.push({
+            // TODO: Removing the & from the string, as this causes errors.  Not
+            // sure if it needs the "amsmath" plugin to be installed somewhere in order
+            // to work?
+            formula: formula.replaceAll('&amp;', ''),
+            index: i,
+          })
+          i++
         }
       })
       return formulas

--- a/src/main.js
+++ b/src/main.js
@@ -4,11 +4,14 @@ import router from './router'
 import store from './store'
 
 import VueHighlightJS from 'vue-highlightjs'
+import VueKatex from 'vue-katex'
 
 import 'highlight.js/styles/xcode.css'
+import 'katex/dist/katex.min.css'
 
 Vue.use(VueHighlightJS)
 Vue.config.productionTip = false
+Vue.use(VueKatex)
 
 new Vue({
   router,


### PR DESCRIPTION
- Swapped out the MathJax dependency for KaTeX instead.
- The maths example page now doesn't throw any errors.
- Note that several LaTeX functions aren't yet supported in KaTeX (or MathJax either!) so have been stripped out.