### PR TITLE
Adding equation block class to MathBlock template

### DIFF
--- a/src/components/templates/MathBlock.vue
+++ b/src/components/templates/MathBlock.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- TODO Not happy with how this works.  If they're rendered as separate equations then relative 
   formatting will fail ... but that's a problem for another day, when the alignment markup is actually recognised! -->
-  <div>
+  <div class="equation-block">
     <div v-for="formula in formulas" :key="'math_' + formula.index">
       <div class="equation" v-katex="formula.formula"></div>
     </div>


### PR DESCRIPTION
To format the `math_block` sections together later on, we need to add a class to the top-level div.