### PR TITLE
Add class to equation blocks so they can be formatted later

### DIFF
--- a/src/components/templates/MathBlock.vue
+++ b/src/components/templates/MathBlock.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="katex-block">
     <div v-for="(formula, index) in formulas" :key="'math_' + index">
       <katex-element :expression="formula"></katex-element>
     </div>


### PR DESCRIPTION
To format the katex blocks later on, we need to add a class to them.  